### PR TITLE
Fix: assigning array values to configuration variables

### DIFF
--- a/src/Listeners/SetLoggerContext.php
+++ b/src/Listeners/SetLoggerContext.php
@@ -2,9 +2,7 @@
 
 namespace Placetopay\Cerberus\Listeners;
 
-use Illuminate\Log\Logger;
 use Illuminate\Log\LogManager;
-use Illuminate\Support\Facades\Log;
 use Spatie\Multitenancy\Events\MadeTenantCurrentEvent;
 
 class SetLoggerContext

--- a/src/Tasks/SwitchTenantTask.php
+++ b/src/Tasks/SwitchTenantTask.php
@@ -2,7 +2,6 @@
 
 namespace Placetopay\Cerberus\Tasks;
 
-use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\DB;
 use Spatie\Multitenancy\Concerns\UsesMultitenancyConfig;
 use Spatie\Multitenancy\Exceptions\InvalidConfiguration;
@@ -66,8 +65,23 @@ class SwitchTenantTask implements \Spatie\Multitenancy\Tasks\SwitchTenantTask
 
         $newConfig = json_decode(str_replace($keywords['keys'], $keywords['values'], $rawConfig), true);
 
-        $dataMapping = Arr::dot($newConfig ?? []);
+        $dataMapping = $this->dot($newConfig ?? []);
 
         config($dataMapping);
+    }
+
+    private function dot(array $array, $prepend = ''): array
+    {
+        $results = [];
+
+        foreach ($array as $key => $value) {
+            if (is_array($value) && !empty($value) && array_filter(array_keys($value), 'is_int') === []) {
+                $results = array_merge($results, $this->dot($value, $prepend . $key . '.'));
+            } else {
+                $results[$prepend . $key] = $value;
+            }
+        }
+
+        return $results;
     }
 }

--- a/tests/Unit/TenantTest.php
+++ b/tests/Unit/TenantTest.php
@@ -90,7 +90,7 @@ class TenantTest extends TestCase
     }
 
     /** @test */
-    public function it_returns_successfully_overwritten_locales(): void
+    public function overwrite_array_keys_config_values_successfully(): void
     {
         config()->set('app.locales', ['en', 'es', 'fr', 'it', 'pt']);
 

--- a/tests/Unit/TenantTest.php
+++ b/tests/Unit/TenantTest.php
@@ -23,6 +23,13 @@ class TenantTest extends TestCase
                    'es_CL' => 'terminos y condiciones chile',
                ],
            ],
+            'app' => [
+                'locales' => [
+                    'es',
+                    'en',
+                    'fr',
+                ],
+            ],
         ];
 
         $this->tenant = factory(Tenant::class)->create([
@@ -80,5 +87,15 @@ class TenantTest extends TestCase
         $this->tenant->makeCurrent();
 
         $this->assertEmpty(app('currentTenant')->translate('terms_and_privacy'));
+    }
+
+    /** @test */
+    public function it_returns_successfully_overwritten_locales(): void
+    {
+        config()->set('app.locales', ['en', 'es', 'fr', 'it', 'pt']);
+
+        $this->tenant->makeCurrent();
+
+        $this->assertEquals(['es', 'en', 'fr'], config('app.locales'));
     }
 }


### PR DESCRIPTION
**TAG v1.8.7**
Configuration variables with array value, do not overwrite the entire variable.
