### PR TITLE
Do not instantiate mailer when switching tenants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [3.0.1 (2023-10-09)](https://github.com/placetopay-org/cerberus/pull/27)
+## [3.0.2 (2023-10-11)](https://github.com/placetopay-org/cerberus/compare/3.0.1...3.0.2)
+
+### Changed
+
+- When switching tenants, the `SwitchMailerTask` will not instantiate a new mailer.
+
+## [3.0.1 (2023-10-09)](https://github.com/placetopay-org/cerberus/compare/3.0.0...3.0.1)
 
 ### Added
 

--- a/src/Tasks/SwitchMailerTask.php
+++ b/src/Tasks/SwitchMailerTask.php
@@ -16,13 +16,11 @@ class SwitchMailerTask implements SwitchTenantTask
 
     public function makeCurrent(Tenant $tenant): void
     {
-        $currentDrive = config('mail.default');
-
-        app('mail.manager')->forgetMailers()->mailer($currentDrive);
+        app('mail.manager')->forgetMailers();
     }
 
     public function forgetCurrent(): void
     {
-        app('mail.manager')->forgetMailers()->mailer($this->originalDrive);
+        app('mail.manager')->forgetMailers();
     }
 }

--- a/tests/Tasks/SwitchMailerTaskTest.php
+++ b/tests/Tasks/SwitchMailerTaskTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Placetopay\Cerberus\Tests\Tasks;
+
+use Illuminate\Mail\Transport\ArrayTransport;
+use Illuminate\Mail\Transport\LogTransport;
+use Placetopay\Cerberus\Models\Tenant;
+use Placetopay\Cerberus\Tests\TestCase;
+
+class SwitchMailerTaskTest extends TestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->tenant = factory(Tenant::class)->create([
+            'app' => config('multitenancy.identifier'),
+            'name' => 'tenant_1',
+            'config' => [
+                'mail' => [
+                    'default' => "array"
+                ],
+            ],
+        ]);
+
+        $this->anotherTenant = factory(Tenant::class)->create([
+            'app' => config('multitenancy.identifier'),
+            'name' => 'tenant_2',
+            'config' => [
+                'mail' => [
+                    'default' => "log"
+                ],
+            ],
+        ]);
+    }
+
+    /** @test */
+    public function it_can_reset_encrypt_container_ok(): void
+    {
+        // Default mail driver is 'smtp'
+        $this->assertInstanceOf(\Swift_SmtpTransport::class, app('mailer')->getSwiftMailer()->getTransport());
+
+        // First tenant mail driver is 'array'
+        $this->tenant->makeCurrent();
+        $this->assertInstanceOf(ArrayTransport::class, app('mailer')->getSwiftMailer()->getTransport());
+
+        // Going back to default, mail driver is 'smtp'
+        Tenant::forgetCurrent();
+        $this->assertInstanceOf(\Swift_SmtpTransport::class, app('mailer')->getSwiftMailer()->getTransport());
+
+        // Switch to another tenant, mail driver is 'log'
+        $this->anotherTenant->makeCurrent();
+        $this->assertInstanceOf(LogTransport::class, app('mailer')->getSwiftMailer()->getTransport());
+    }
+}

--- a/tests/Tasks/SwitchMailerTaskTest.php
+++ b/tests/Tasks/SwitchMailerTaskTest.php
@@ -35,7 +35,7 @@ class SwitchMailerTaskTest extends TestCase
     }
 
     /** @test */
-    public function it_can_reset_encrypt_container_ok(): void
+    public function it_resets_mailer_on_every_tenant(): void
     {
         // Default mail driver is 'smtp'
         $this->assertInstanceOf(\Swift_SmtpTransport::class, app('mailer')->getSwiftMailer()->getTransport());


### PR DESCRIPTION
- When switching tenants, the `SwitchMailerTask` will not instantiate a new mailer.