### PR TITLE
Feature/upgrade spatie multitenancy laralvel 12

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -32,7 +32,7 @@ jobs:
       - name: PHP Setup
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.0'
+          php-version: '8.2'
           extensions: mbstring, dom, fileinfo, mysql
           coverage: xdebug
 

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 .phpunit.result.cache
 composer.lock
 .php-cs-fixer.cache
+phpunit.xml

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 composer.lock
 .php-cs-fixer.cache
 phpunit.xml
+.phpunit.cache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.0.0 (2025-05-16)](https://github.com/placetopay-org/cerberus/compare/4.0.0...3.0.5)
+
+### Changed
+
+- Upgrades runtime to php `8.2`
+- Upgrade the `spatie/laravel-multitenancy` package to version `4.0.x`.
+- Upgrade the `phpUnit` package to version `11.5.x`.
+- Upgrade `orchestra/testbench` to version `10.3.x`,
+- Upgrade `friendsofphp/php-cs-fixer` to version `3.75.x`,
+
 ## [3.0.5 (2025-01-31)](https://github.com/placetopay-org/cerberus/compare/3.0.5...3.0.4)
 
 ### Fixed:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Upgrade the `phpUnit` package to version `11.5.x`.
 - Upgrade `orchestra/testbench` to version `10.3.x`,
 - Upgrade `friendsofphp/php-cs-fixer` to version `3.75.x`,
+- Removes  `laravel/legacy-factories`
 
 ## [3.0.5 (2025-01-31)](https://github.com/placetopay-org/cerberus/compare/3.0.5...3.0.4)
 

--- a/README.md
+++ b/README.md
@@ -9,15 +9,15 @@ Because it is a customization, it requires override steps mentioned below for pr
 This package aims to standardize the configuration of the ``tenants`` table of the landlord database, in addition to reducing the number of queries made to the same database by using cache.
 
 ## Prerequsites
-- `php8.0+`
-- `Laravel 8.0+`
+- `php8.2+`
+- `Laravel ^11.0|^12.0`
 
 ## Installation
 
 This package can be installed via composer:
 
 ``` bash
-composer require "placetopay/cerberus:^3.0"
+composer require "placetopay/cerberus:^4.0"
 ```
 
 ### Publishing the config file

--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,7 @@
     "require-dev": {
         "phpunit/phpunit": "^11.5",
         "orchestra/testbench": "^10.3",
-        "friendsofphp/php-cs-fixer": "^3.75",
-        "laravel/legacy-factories": "^1.0.4"
+        "friendsofphp/php-cs-fixer": "^3.75"
     },
     "autoload": {
         "psr-4": {
@@ -34,6 +33,7 @@
             "Placetopay\\Cerberus\\Tests\\": "tests"
         },
         "classmap": [
+            "database/factories",
             "tests/database/migrations/landlord"
         ]
     },

--- a/composer.json
+++ b/composer.json
@@ -13,15 +13,15 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.2",
         "ext-json": "*",
-        "spatie/laravel-multitenancy": "^3.0",
+        "spatie/laravel-multitenancy": "^4.0",
         "eduarguz/shift-php-cs": "^3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5",
-        "orchestra/testbench": "^6.0",
-        "friendsofphp/php-cs-fixer": "^3.0",
+        "phpunit/phpunit": "^11.5",
+        "orchestra/testbench": "^10.3",
+        "friendsofphp/php-cs-fixer": "^3.75",
         "laravel/legacy-factories": "^1.0.4"
     },
     "autoload": {

--- a/config/multitenancy.php
+++ b/config/multitenancy.php
@@ -4,6 +4,7 @@ use Illuminate\Broadcasting\BroadcastEvent;
 use Illuminate\Events\CallQueuedListener;
 use Illuminate\Mail\SendQueuedMailable;
 use Illuminate\Notifications\SendQueuedNotifications;
+use Illuminate\Queue\CallQueuedClosure;
 use Placetopay\Cerberus\Actions\MakeQueueTenantAwareAction;
 use Placetopay\Cerberus\Models\Tenant;
 use Placetopay\Cerberus\Tasks\FilesystemSuffixedTask;
@@ -17,37 +18,21 @@ use Spatie\Multitenancy\Actions\MigrateTenantAction;
 use Spatie\Multitenancy\Tasks\PrefixCacheTask;
 
 return [
-    /**
-     * This name identifies the project for a central database that uses multiple tenants.
-     */
-    'identifier' => env('APP_IDENTIFIER', 'main'),
-
-    /**
-     * Array of drivers that will be suffixed with tenant_name.
-     */
-    'filesystems_disks' => [
-        'local',
-        'public',
-        //s3
-    ],
-
-    /**
-     * suffix storage_path
-     * Note: Disable this if you're using an external file storage service like S3.
-     *
-     * If you need to overwrite the storage_path() you must ensure that you have the folder structure for the application
-     * cache storage in the storage folder, you can create this structure by executing the command ...
-     */
-    'suffix_storage_path' => false,
+    /*
+    * This class is responsible for determining which tenant should be current
+    * for the given request.
+    *
+    * This class should extend `Spatie\Multitenancy\TenantFinder\TenantFinder`
+    *
+    */
+    'tenant_finder' => DomainTenantFinder::class,
 
     /*
-     * This class is responsible for determining which tenant should be current
-     * for the given request.
-     *
-     * This class should extend `Spatie\Multitenancy\TenantFinder\TenantFinder`
-     *
-     */
-    'tenant_finder' => DomainTenantFinder::class,
+    * These fields are used by tenant:artisan command to match one or more tenant.
+    */
+    'tenant_artisan_search_fields' => [
+        'id',
+    ],
 
     /*
      * These tasks will be performed when switching tenants.
@@ -70,10 +55,10 @@ return [
     'tenant_model' => Tenant::class,
 
     /*
-     * If there is a current tenant when dispatching a job, the id of the current tenant
-     * will be automatically set on the job. When the job is executed, the set
-     * tenant on the job will be made current.
-     */
+    * If there is a current tenant when dispatching a job, the id of the current tenant
+    * will be automatically set on the job. When the job is executed, the set
+    * tenant on the job will be made current.
+    */
     'queues_are_tenant_aware_by_default' => true,
 
     /*
@@ -89,32 +74,88 @@ return [
     'landlord_database_connection_name' => env('DB_LANDLORD_CONNECTION', 'landlord'),
 
     /*
-     * This key will be used to bind the current tenant in the container.
-     */
+    * This key will be used to associate the current tenant in the context
+    */
+    'current_tenant_context_key' => 'tenantId',
+
+    /*
+    * This key will be used to bind the current tenant in the container.
+    */
     'current_tenant_container_key' => 'currentTenant',
 
     /*
-     * You can customize some of the behavior of this package by using our own custom action.
-     * Your custom action should always extend the default one.
-     */
+    * Set it to `true` if you like to cache the tenant(s) routes
+    * in a shared file using the `SwitchRouteCacheTask`.
+    */
+    'shared_routes_cache' => false,
+
+    /*
+    * You can customize some of the behavior of this package by using our own custom action.
+    * Your custom action should always extend the default one.
+    */
     'actions' => [
         'make_tenant_current_action' => MakeTenantCurrentAction::class,
         'forget_current_tenant_action' => ForgetCurrentTenantAction::class,
         'make_queue_tenant_aware_action' => MakeQueueTenantAwareAction::class,
         'migrate_tenant' => MigrateTenantAction::class,
     ],
+
     /*
-     * You can customize the way in which the package resolves the queuable to a job.
-     *
-     * For example, using the package laravel-actions (by Loris Leiva), you can
-     * resolve JobDecorator to getAction() like so: JobDecorator::class => 'getAction'
-     */
+    * You can customize the way in which the package resolves the queueable to a job.
+    *
+    * For example, using the package laravel-actions (by Loris Leiva), you can
+    * resolve JobDecorator to getAction() like so: JobDecorator::class => 'getAction'
+    */
     'queueable_to_job' => [
         SendQueuedMailable::class => 'mailable',
         SendQueuedNotifications::class => 'notification',
+        CallQueuedClosure::class => 'closure',
         CallQueuedListener::class => 'class',
         BroadcastEvent::class => 'event',
     ],
+
+    /*
+    * Jobs tenant aware even if these don't implement the TenantAware interface.
+    */
+    'tenant_aware_jobs' => [
+        // ...
+    ],
+
+    /*
+    * Jobs not tenant aware even if these don't implement the NotTenantAware interface.
+    */
+    'not_tenant_aware_jobs' => [
+        // ...
+    ],
+
+    /*
+     |--------------------------------------------------------------------------
+     |  Placetopay Configs
+     |--------------------------------------------------------------------------
+     */
+
+    /**
+     * Array of drivers that will be suffixed with tenant_name.
+     */
+    'filesystems_disks' => [
+        'local',
+        'public',
+        //s3
+    ],
+
+    /**
+     * suffix storage_path
+     * Note: Disable this if you're using an external file storage service like S3.
+     *
+     * If you need to overwrite the storage_path() you must ensure that you have the folder structure for the application
+     * cache storage in the storage folder, you can create this structure by executing the command ...
+     */
+    'suffix_storage_path' => false,
+
+    /**
+     * This name identifies the project for a central database that uses multiple tenants.
+     */
+    'identifier' => env('APP_IDENTIFIER', 'main'),
 
     /**
      * You need to set up this key to use in the middleware to validate when someone application wants to clear cache remotely.

--- a/database/factories/TenantFactory.php
+++ b/database/factories/TenantFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Placetopay\Cerberus\Models\Tenant;
+
+class TenantFactory extends Factory
+{
+    protected $model = Tenant::class;
+
+    public function definition(): array
+    {
+        return [
+            'app' => config('multitenancy.identifier'),
+            'name' => $this->faker->company(),
+            'domain' => $this->faker->unique()->domainName(),
+            'config' => [
+                'app' => [
+                    'env' => 'local',
+                    'name' => 'Colombia',
+                    'debug' => true,
+                    'locale' => 'es',
+                    'timezone' => 'America/Bogota',
+                ],
+            ],
+        ];
+    }
+}

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -12,12 +12,15 @@
         </testsuite>
     </testsuites>
     <php>
-        <env name="CACHE_DRIVER" value="array"/>
         <env name="APP_KEY" value="base64:m+pDa0MKS1KpMlxzzdVEaqFHysv3IPhrx/3TFSWBqJA="/>
-        <env name="DB_USERNAME" value="root"/>
-        <env name="DB_PASSWORD" value=""/>
+        <env name="CACHE_DRIVER" value="array"/>
+        <env name="DB_CONNECTION" value="mysql"/>
         <env name="DB_HOST" value="127.0.0.1"/>
         <env name="DB_PORT" value="3306"/>
+        <env name="DB_DATABASE" value="laravel_mt_landlord"/>
+        <env name="DB_USERNAME" value="root"/>
+        <env name="DB_PASSWORD" value=""/>
+        <env name="QUEUE_CONNECTION" value="database"/>
         <env name="APP_VANITY_URL" value=""/>
     </php>
     <source>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -17,7 +17,6 @@
         <env name="DB_CONNECTION" value="mysql"/>
         <env name="DB_HOST" value="127.0.0.1"/>
         <env name="DB_PORT" value="3306"/>
-        <env name="DB_DATABASE" value="laravel_mt_landlord"/>
         <env name="DB_USERNAME" value="root"/>
         <env name="DB_PASSWORD" value=""/>
         <env name="QUEUE_CONNECTION" value="database"/>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,31 +1,28 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="vendor/autoload.php"
-         backupGlobals="false"
-         backupStaticAttributes="false"
-         colors="true"
-         verbose="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" colors="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
     <testsuites>
-        <testsuite name="Placetopay Test Suite">
-            <directory>tests</directory>
+        <testsuite name="Feature">
+            <directory suffix="Test.php">./tests/Feature</directory>
+        </testsuite>
+        <testsuite name="Task">
+            <directory suffix="Test.php">./tests/Tasks</directory>
+        </testsuite>
+        <testsuite name="Unit">
+            <directory suffix="Test.php">./tests/Unit</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">src/</directory>
-        </whitelist>
-    </filter>
     <php>
         <env name="CACHE_DRIVER" value="array"/>
-        <env name="APP_KEY" value="base64:m+pDa0MKS1KpMlxzzdVEaqFHysv3IPhrx/3TFSWBqJA=" />
+        <env name="APP_KEY" value="base64:m+pDa0MKS1KpMlxzzdVEaqFHysv3IPhrx/3TFSWBqJA="/>
         <env name="DB_USERNAME" value="root"/>
         <env name="DB_PASSWORD" value=""/>
-        <env name="DB_HOST" value="127.0.0.1" />
-        <env name="DB_PORT" value="3306" />
-        <env name="APP_VANITY_URL" value="" />
+        <env name="DB_HOST" value="127.0.0.1"/>
+        <env name="DB_PORT" value="3306"/>
+        <env name="APP_VANITY_URL" value=""/>
     </php>
+    <source>
+        <include>
+            <directory suffix=".php">src/</directory>
+        </include>
+    </source>
 </phpunit>

--- a/src/Commands/Concerns/TenantAware.php
+++ b/src/Commands/Concerns/TenantAware.php
@@ -5,25 +5,24 @@ namespace Placetopay\Cerberus\Commands\Concerns;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Cache;
 use Spatie\Multitenancy\Concerns\UsesMultitenancyConfig;
-use Spatie\Multitenancy\Models\Concerns\UsesTenantModel;
+use Spatie\Multitenancy\Contracts\IsTenant;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 trait TenantAware
 {
-    use UsesMultitenancyConfig,
-        UsesTenantModel;
+    use UsesMultitenancyConfig;
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $tenant = Arr::wrap($this->option('tenant'));
         if (empty($tenant)) {
-            $tenant = $this->getTenantModel()::query()->pluck('domain')->toArray();
+            $tenant = app(IsTenant::class)::query()->pluck('domain')->toArray();
         }
 
         $tenants = collect($tenant)->map(
             fn ($domain) => Cache::rememberForever("tenant_{$domain}", function () use ($domain) {
-                return $this->getTenantModel()::query()->whereDomain($domain)->first();
+                return app(IsTenant::class)::query()->whereDomain($domain)->first();
             })
         )->filter();
 

--- a/src/Commands/TenantsArtisanCommand.php
+++ b/src/Commands/TenantsArtisanCommand.php
@@ -5,7 +5,7 @@ namespace Placetopay\Cerberus\Commands;
 use Illuminate\Support\Facades\Artisan;
 use Placetopay\Cerberus\Commands\Concerns\TenantAware;
 use Spatie\Multitenancy\Commands\TenantsArtisanCommand as TenantsArtisanParentCommand;
-use Spatie\Multitenancy\Models\Tenant;
+use Spatie\Multitenancy\Contracts\IsTenant;
 
 class TenantsArtisanCommand extends TenantsArtisanParentCommand
 {
@@ -20,7 +20,7 @@ class TenantsArtisanCommand extends TenantsArtisanParentCommand
      *
      * @return void
      */
-    public function handle()
+    public function handle(): void
     {
         if (! $artisanCommand = $this->argument('artisanCommand')) {
             $artisanCommand = $this->ask('Which artisan command do you want to run for all tenants?');
@@ -30,10 +30,10 @@ class TenantsArtisanCommand extends TenantsArtisanParentCommand
             $artisanCommand = addslashes($artisanCommand);
         }
 
-        $tenant = Tenant::current();
+        $tenant = app(IsTenant::class)::current();
 
         $this->line('');
-        $this->info("Running command for tenant `{$tenant->name}` (id: {$tenant->getKey()})...");
+        $this->info("Running command for tenant `$tenant->name` (id: {$tenant->getKey()})...");
         $this->line('---------------------------------------------------------');
 
         Artisan::call($artisanCommand, [], $this->output);

--- a/src/Commands/TenantsListCommand.php
+++ b/src/Commands/TenantsListCommand.php
@@ -4,19 +4,17 @@ namespace Placetopay\Cerberus\Commands;
 
 use Illuminate\Console\Command;
 use Placetopay\Cerberus\Models\Tenant;
-use Spatie\Multitenancy\Models\Concerns\UsesTenantModel;
+use Spatie\Multitenancy\Contracts\IsTenant;
 
 class TenantsListCommand extends Command
 {
-    use UsesTenantModel;
-
     protected $signature = 'tenants:list';
 
     protected $description = 'List tenants.';
 
     public function handle(): void
     {
-        $tenantQuery = $this->getTenantModel()::query();
+        $tenantQuery = app(IsTenant::class)::query();
 
         $this->info("Listing all tenants ({$tenantQuery->count()}).");
 

--- a/src/Models/Tenant.php
+++ b/src/Models/Tenant.php
@@ -2,6 +2,8 @@
 
 namespace Placetopay\Cerberus\Models;
 
+use Database\Factories\TenantFactory;
+use Illuminate\Database\Eloquent\Factories\Factory;
 use Placetopay\Cerberus\Scopes\AppScope;
 use Spatie\Multitenancy\Contracts\IsTenant;
 use Spatie\Multitenancy\Models\Tenant as TenantSpatie;
@@ -68,5 +70,10 @@ class Tenant extends TenantSpatie implements IsTenant
     private function shortLocale($locale): string
     {
         return strtolower(substr($locale, 0, 2));
+    }
+
+    protected static function newFactory(): Factory
+    {
+        return TenantFactory::new();
     }
 }

--- a/src/Models/Tenant.php
+++ b/src/Models/Tenant.php
@@ -3,6 +3,7 @@
 namespace Placetopay\Cerberus\Models;
 
 use Placetopay\Cerberus\Scopes\AppScope;
+use Spatie\Multitenancy\Contracts\IsTenant;
 use Spatie\Multitenancy\Models\Tenant as TenantSpatie;
 
 /**
@@ -12,7 +13,7 @@ use Spatie\Multitenancy\Models\Tenant as TenantSpatie;
  * @property string domain
  * @property array config
  */
-class Tenant extends TenantSpatie
+class Tenant extends TenantSpatie implements IsTenant
 {
     protected $fillable = ['config'];
 

--- a/src/Tasks/FilesystemSuffixedTask.php
+++ b/src/Tasks/FilesystemSuffixedTask.php
@@ -5,7 +5,7 @@ namespace Placetopay\Cerberus\Tasks;
 use Illuminate\Foundation\Application;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
-use Spatie\Multitenancy\Models\Tenant;
+use Spatie\Multitenancy\Contracts\IsTenant;
 use Spatie\Multitenancy\Tasks\SwitchTenantTask;
 
 class FilesystemSuffixedTask implements SwitchTenantTask
@@ -30,7 +30,7 @@ class FilesystemSuffixedTask implements SwitchTenantTask
         });
     }
 
-    public function makeCurrent(Tenant $tenant): void
+    public function makeCurrent(IsTenant $tenant): void
     {
         $suffix = "tenants/$tenant->name";
 

--- a/src/Tasks/ResetInstancesTask.php
+++ b/src/Tasks/ResetInstancesTask.php
@@ -2,12 +2,12 @@
 
 namespace Placetopay\Cerberus\Tasks;
 
-use Spatie\Multitenancy\Models\Tenant;
+use Spatie\Multitenancy\Contracts\IsTenant;
 use Spatie\Multitenancy\Tasks\SwitchTenantTask;
 
 class ResetInstancesTask implements SwitchTenantTask
 {
-    public function makeCurrent(Tenant $tenant): void
+    public function makeCurrent(IsTenant $tenant): void
     {
     }
 

--- a/src/Tasks/SwitchMailerTask.php
+++ b/src/Tasks/SwitchMailerTask.php
@@ -2,7 +2,7 @@
 
 namespace Placetopay\Cerberus\Tasks;
 
-use Spatie\Multitenancy\Models\Tenant;
+use Spatie\Multitenancy\Contracts\IsTenant;
 use Spatie\Multitenancy\Tasks\SwitchTenantTask;
 
 class SwitchMailerTask implements SwitchTenantTask
@@ -14,7 +14,7 @@ class SwitchMailerTask implements SwitchTenantTask
         $this->originalDrive ??= config('mail.default');
     }
 
-    public function makeCurrent(Tenant $tenant): void
+    public function makeCurrent(IsTenant $tenant): void
     {
         app('mail.manager')->forgetMailers();
     }

--- a/src/Tasks/SwitchTenantTask.php
+++ b/src/Tasks/SwitchTenantTask.php
@@ -4,6 +4,7 @@ namespace Placetopay\Cerberus\Tasks;
 
 use Illuminate\Support\Facades\DB;
 use Spatie\Multitenancy\Concerns\UsesMultitenancyConfig;
+use Spatie\Multitenancy\Contracts\IsTenant;
 use Spatie\Multitenancy\Exceptions\InvalidConfiguration;
 use Spatie\Multitenancy\Models\Tenant;
 
@@ -22,7 +23,7 @@ class SwitchTenantTask implements \Spatie\Multitenancy\Tasks\SwitchTenantTask
      * @param Tenant $tenant
      * @throws InvalidConfiguration
      */
-    public function makeCurrent(Tenant $tenant): void
+    public function makeCurrent(IsTenant $tenant): void
     {
         $this->setConfig($tenant);
         $this->purgeConnectionDatabase();

--- a/src/TenantFinder/DomainTenantFinder.php
+++ b/src/TenantFinder/DomainTenantFinder.php
@@ -4,16 +4,13 @@ namespace Placetopay\Cerberus\TenantFinder;
 
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Cache;
+use Spatie\Multitenancy\Contracts\IsTenant;
 use Spatie\Multitenancy\Landlord;
-use Spatie\Multitenancy\Models\Concerns\UsesTenantModel;
-use Spatie\Multitenancy\Models\Tenant;
 use Spatie\Multitenancy\TenantFinder\TenantFinder;
 
 class DomainTenantFinder extends TenantFinder
 {
-    use UsesTenantModel;
-
-    public function findForRequest(Request $request): ?Tenant
+    public function findForRequest(Request $request): ?IsTenant
     {
         $domain = $request->getHost().str_replace('/index.php', '', $request->getBaseUrl());
         $vanityUrl = $_ENV['APP_VANITY_URL'] ?? '';
@@ -25,11 +22,11 @@ class DomainTenantFinder extends TenantFinder
         return $this->getTenant($domain);
     }
 
-    public function getTenant($domain)
+    public function getTenant($domain): ?IsTenant
     {
         return Landlord::execute(function () use ($domain) {
-            return Cache::rememberForever("tenant_{$domain}", function () use ($domain) {
-                return $this->getTenantModel()::query()->whereDomain($domain)->first();
+            return Cache::rememberForever("tenant_$domain", function () use ($domain) {
+                return app(IsTenant::class)::query()->whereDomain($domain)->first();
             });
         });
     }

--- a/tests/Feature/Actions/MakeQueueTenantAwareActionTest.php
+++ b/tests/Feature/Actions/MakeQueueTenantAwareActionTest.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Feature\Actions;
+
+use Illuminate\Queue\CallQueuedHandler;
+use Illuminate\Queue\Events\JobFailed;
+use Illuminate\Support\Facades\Event;
+use PHPUnit\Framework\Attributes\Test;
+use Placetopay\Cerberus\Models\Tenant;
+use Placetopay\Cerberus\Tests\Support\NonTenantAwareJob;
+use Placetopay\Cerberus\Tests\Support\TestTenantDomainJob;
+use Placetopay\Cerberus\Tests\Support\Traits\InteractsWithLogs;
+use Placetopay\Cerberus\Tests\TestCase;
+
+class MakeQueueTenantAwareActionTest extends TestCase
+{
+    use InteractsWithLogs;
+
+    private Tenant $tenant;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Event::fake(JobFailed::class);
+
+        $this->tenant = Tenant::factory()->create([
+            'app' => config('multitenancy.identifier'),
+            'domain' => 'tenant.cerberus.test',
+            'name' => 'Cerberus Colombia',
+        ]);
+
+        Event::assertNotDispatched(JobFailed::class);
+    }
+
+    #[Test]
+    public function it_processes_job_with_tenant_domain_and_sets_context()
+    {
+        $this->fakeLogs();
+
+        $this->tenant->makeCurrent();
+        dispatch(new TestTenantDomainJob($this->tenant->name));
+
+        $this->assertEmpty($this->getAllLogMessages());
+
+        $tenantJob = \DB::table('jobs')->first();
+
+        $this->assertIsInt($tenantJob->id);
+        $this->assertSame('default', $tenantJob->queue);
+        $payload = json_decode($tenantJob->payload, true);
+
+        $this->assertCount(14, $payload);
+
+        $this->assertIsString($payload['uuid']);
+        $this->assertSame(TestTenantDomainJob::class, $payload['displayName']);
+        $this->assertStringContainsString(CallQueuedHandler::class, $payload['job']);
+
+        $this->assertNull($payload['maxTries']);
+        $this->assertNull($payload['maxExceptions']);
+        $this->assertFalse($payload['failOnTimeout']);
+        $this->assertNull($payload['backoff']);
+        $this->assertNull($payload['timeout']);
+        $this->assertNull($payload['retryUntil']);
+
+        $this->assertSame(TestTenantDomainJob::class, $payload['data']['commandName']);
+        $this->assertStringStartsWith('O:', $payload['data']['command']);
+        $this->assertStringContainsString(TestTenantDomainJob::class, $payload['data']['command']);
+
+        $this->assertIsInt($payload['createdAt']);
+        $this->assertArrayHasKey('tenantId', $payload['illuminate:log:context']['data']);
+
+        $this->assertEquals($this->tenant->domain, $payload['tenantDomain']);
+        $this->assertNull($payload['delay']);
+
+        /*** Running Jobs */
+        $this->artisan('queue:work', ['--once' => true])->assertExitCode(0);
+
+        $this->assertSame(0, \DB::table('jobs')->count());
+
+        $this->assertLogMessageContains("Tenant {$this->tenant->name}: TestTenantDomainJob started");
+    }
+
+    #[Test]
+    public function it_does_not_add_tenant_domain_if_job_is_not_tenant_aware()
+    {
+        $this->fakeLogs();
+
+        $this->tenant->makeCurrent();
+
+        $this->assertEmpty($this->getAllLogMessages());
+
+        dispatch(new NonTenantAwareJob());
+
+        $job = \DB::table('jobs')->latest('id')->count();
+
+        $this->assertSame(1, $job);
+
+        /*** Running Jobs */
+        $this->artisan('queue:work', ['--once' => true])->assertExitCode(0);
+
+        $this->assertEmpty($this->getAllLogMessages());
+    }
+}

--- a/tests/Feature/CacheTest.php
+++ b/tests/Feature/CacheTest.php
@@ -4,10 +4,12 @@ namespace Placetopay\Cerberus\Tests\Feature;
 
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Cache;
+use PHPUnit\Framework\Attributes\Test;
 use Placetopay\Cerberus\Models\Tenant;
 use Placetopay\Cerberus\Tasks\SwitchTenantTask;
 use Placetopay\Cerberus\TenantFinder\DomainTenantFinder;
 use Placetopay\Cerberus\Tests\TestCase;
+use Spatie\Multitenancy\Contracts\IsTenant;
 
 class CacheTest extends TestCase
 {
@@ -34,10 +36,10 @@ class CacheTest extends TestCase
 
         $this->tenant->makeCurrent();
 
-        Tenant::forgetCurrent();
+        app(IsTenant::class)::forgetCurrent();
     }
 
-    /** @test */
+    #[Test]
     public function it_print_the_correct_tenant_checking_cache()
     {
         $this
@@ -57,7 +59,7 @@ class CacheTest extends TestCase
             ->expectsOutput('Tenant Config is '.$this->tenant->getRawOriginal('config'));
     }
 
-    /** @test */
+    #[Test]
     public function it_can_find_a_tenant_for_the_current_domain_checking_cache()
     {
         $request = Request::create(sprintf('https://%s', $this->tenant->domain));
@@ -71,7 +73,7 @@ class CacheTest extends TestCase
         $this->assertEquals($this->tenant->config, $this->tenantFinder->findForRequest($request)->config);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_cache_domain_via_tenant_finder()
     {
         $request = Request::create(sprintf('https://%s', $this->tenant->domain));
@@ -89,7 +91,7 @@ class CacheTest extends TestCase
             ->expectsOutput('Tenant Config is '.$this->tenant->getRawOriginal('config'));
     }
 
-    /** @test */
+    #[Test]
     public function it_can_cache_domain_via_tenant_aware()
     {
         $this

--- a/tests/Feature/CacheTest.php
+++ b/tests/Feature/CacheTest.php
@@ -27,7 +27,7 @@ class CacheTest extends TestCase
 
         config()->set('multitenancy.switch_tenant_tasks', [SwitchTenantTask::class]);
 
-        $this->tenant = factory(Tenant::class)->create([
+        $this->tenant = Tenant::factory()->create([
             'app' => config('multitenancy.identifier'),
             'name' => 'tenant_1',
             'domain' => 'co.domain.com',

--- a/tests/Feature/Commands/TenantAwareCommandTest.php
+++ b/tests/Feature/Commands/TenantAwareCommandTest.php
@@ -22,7 +22,7 @@ class TenantAwareCommandTest extends TestCase
 
         config()->set('multitenancy.switch_tenant_tasks', [SwitchTenantTask::class]);
 
-        $this->tenant = factory(Tenant::class)->create([
+        $this->tenant = Tenant::factory()->create([
             'app' => config('multitenancy.identifier'),
             'name' => 'tenant_1',
             'domain' => 'co.domain.com',
@@ -31,7 +31,7 @@ class TenantAwareCommandTest extends TestCase
 
         $this->tenant->makeCurrent();
 
-        $this->anotherTenant = factory(Tenant::class)->create([
+        $this->anotherTenant = Tenant::factory()->create([
             'app' => config('multitenancy.identifier'),
             'name' => 'tenant_2',
             'domain' => 'pr.domain.com',

--- a/tests/Feature/Commands/TenantAwareCommandTest.php
+++ b/tests/Feature/Commands/TenantAwareCommandTest.php
@@ -2,9 +2,11 @@
 
 namespace Placetopay\Cerberus\Tests\Feature\Commands;
 
+use PHPUnit\Framework\Attributes\Test;
 use Placetopay\Cerberus\Models\Tenant;
 use Placetopay\Cerberus\Tasks\SwitchTenantTask;
 use Placetopay\Cerberus\Tests\TestCase;
+use Spatie\Multitenancy\Contracts\IsTenant;
 
 class TenantAwareCommandTest extends TestCase
 {
@@ -37,10 +39,10 @@ class TenantAwareCommandTest extends TestCase
         ]);
         $this->anotherTenant->makeCurrent();
 
-        Tenant::forgetCurrent();
+        app(IsTenant::class)::forgetCurrent();
     }
 
-    /** @test */
+    #[Test]
     public function it_fails_with_a_not_existent_tenant()
     {
         $this
@@ -49,7 +51,7 @@ class TenantAwareCommandTest extends TestCase
             ->expectsOutput('No tenant(s) found.');
     }
 
-    /** @test */
+    #[Test]
     public function it_prints_the_right_tenant()
     {
         $this
@@ -58,7 +60,7 @@ class TenantAwareCommandTest extends TestCase
             ->expectsOutput('Tenant ID is '.$this->tenant->id);
     }
 
-    /** @test */
+    #[Test]
     public function it_works_with_no_tenant_parameters()
     {
         $this

--- a/tests/Feature/Commands/TenantsArtisanCommandTest.php
+++ b/tests/Feature/Commands/TenantsArtisanCommandTest.php
@@ -3,8 +3,10 @@
 namespace Placetopay\Cerberus\Tests\Feature\Commands;
 
 use Illuminate\Support\Facades\Schema;
+use PHPUnit\Framework\Attributes\Test;
 use Placetopay\Cerberus\Models\Tenant;
 use Placetopay\Cerberus\Tests\TestCase;
+use Spatie\Multitenancy\Contracts\IsTenant;
 
 class TenantsArtisanCommandTest extends TestCase
 {
@@ -37,10 +39,10 @@ class TenantsArtisanCommandTest extends TestCase
         $this->anotherTenant->makeCurrent();
         Schema::connection('tenant')->dropIfExists('migrations');
 
-        Tenant::forgetCurrent();
+        app(IsTenant::class)::forgetCurrent();
     }
 
-    /** @test */
+    #[Test]
     public function it_can_migrate_all_tenant_databases()
     {
         $this
@@ -52,7 +54,7 @@ class TenantsArtisanCommandTest extends TestCase
             ->assertTenantDatabaseHasTable($this->anotherTenant, 'migrations');
     }
 
-    /** @test */
+    #[Test]
     public function it_can_migrate_a_specific_tenant()
     {
         $this->artisan('tenants:artisan migrate --tenant="'.$this->anotherTenant->domain.'"')
@@ -63,14 +65,14 @@ class TenantsArtisanCommandTest extends TestCase
             ->assertTenantDatabaseHasTable($this->anotherTenant, 'migrations');
     }
 
-    /** @test */
+    #[Test]
     public function it_cant_migrate_a_specific_tenant_id_when_search_by_domain()
     {
         $this->artisan('tenants:artisan migrate --tenant="'.$this->anotherTenant->name.'"')
             ->expectsOutput('No tenant(s) found.');
     }
 
-    /** @test */
+    #[Test]
     public function it_can_migrate_a_specific_tenant_by_domain()
     {
         $this->artisan('tenants:artisan migrate --tenant="'.$this->anotherTenant->domain.'"')
@@ -81,7 +83,7 @@ class TenantsArtisanCommandTest extends TestCase
             ->assertTenantDatabaseHasTable($this->anotherTenant, 'migrations');
     }
 
-    /** @test */
+    #[Test]
     public function it_works_with_parameters_that_contain_spaces()
     {
         $this->artisan('tenants:artisan "echo:argument hello" --no-slashes --tenant="'.$this->anotherTenant->domain.'"')
@@ -117,7 +119,7 @@ class TenantsArtisanCommandTest extends TestCase
 
         $tenantHasDatabaseTable = Schema::connection('tenant')->hasTable($tableName);
 
-        Tenant::forgetCurrent();
+        app(IsTenant::class)::forgetCurrent();
 
         return $tenantHasDatabaseTable;
     }

--- a/tests/Feature/Commands/TenantsArtisanCommandTest.php
+++ b/tests/Feature/Commands/TenantsArtisanCommandTest.php
@@ -20,7 +20,7 @@ class TenantsArtisanCommandTest extends TestCase
 
         config(['database.default' => 'tenant']);
 
-        $this->tenant = factory(Tenant::class)->create([
+        $this->tenant = Tenant::factory()->create([
             'app' => config('multitenancy.identifier'),
             'name' => 'tenant_1',
             'domain' => 'co.domain.com',
@@ -30,7 +30,7 @@ class TenantsArtisanCommandTest extends TestCase
 
         Schema::connection('tenant')->dropIfExists('migrations');
 
-        $this->anotherTenant = factory(Tenant::class)->create([
+        $this->anotherTenant = Tenant::factory()->create([
             'app' => config('multitenancy.identifier'),
             'name' => 'tenant_2',
             'domain' => 'pr.domain.com',

--- a/tests/Feature/Commands/TenantsListCommandTest.php
+++ b/tests/Feature/Commands/TenantsListCommandTest.php
@@ -2,6 +2,7 @@
 
 namespace Placetopay\Cerberus\Tests\Feature\Commands;
 
+use PHPUnit\Framework\Attributes\Test;
 use Placetopay\Cerberus\Models\Tenant;
 use Placetopay\Cerberus\Tests\TestCase;
 
@@ -26,7 +27,7 @@ class TenantsListCommandTest extends TestCase
         ]);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_list_the_tenencies_of_the_app()
     {
         $this

--- a/tests/Feature/Commands/TenantsListCommandTest.php
+++ b/tests/Feature/Commands/TenantsListCommandTest.php
@@ -12,14 +12,14 @@ class TenantsListCommandTest extends TestCase
     {
         parent::setUp();
 
-        factory(Tenant::class)->create([
+        Tenant::factory()->create([
             'app' => config('multitenancy.identifier'),
             'name' => 'tenant_1',
             'domain' => 'co.domain.com',
             'config' => $this->getConfigStructure('laravel_mt_tenant_1'),
         ]);
 
-        factory(Tenant::class)->create([
+        Tenant::factory()->create([
             'app' => 'other',
             'name' => 'tenant_2',
             'domain' => 'pr.domain.com',

--- a/tests/Feature/Commands/TenantsSkeletonStorageCommandTest.php
+++ b/tests/Feature/Commands/TenantsSkeletonStorageCommandTest.php
@@ -19,14 +19,14 @@ class TenantsSkeletonStorageCommandTest extends TestCase
 
         config()->set('multitenancy.suffix_storage_path', true);
 
-        $this->tenant = factory(Tenant::class)->create([
+        $this->tenant = Tenant::factory()->create([
             'app' => config('multitenancy.identifier'),
             'name' => 'co',
             'domain' => 'co.domain.com',
             'config' => $this->getConfigStructure('laravel_mt_tenant_1'),
         ]);
 
-        $this->anotherTenant = factory(Tenant::class)->create([
+        $this->anotherTenant = Tenant::factory()->create([
             'app' => config('multitenancy.identifier'),
             'name' => 'pr',
             'domain' => 'pr.domain.com',

--- a/tests/Feature/Commands/TenantsSkeletonStorageCommandTest.php
+++ b/tests/Feature/Commands/TenantsSkeletonStorageCommandTest.php
@@ -3,6 +3,7 @@
 namespace Placetopay\Cerberus\Tests\Feature\Commands;
 
 use Illuminate\Support\Facades\File;
+use PHPUnit\Framework\Attributes\Test;
 use Placetopay\Cerberus\Models\Tenant;
 use Placetopay\Cerberus\Tests\TestCase;
 
@@ -35,7 +36,7 @@ class TenantsSkeletonStorageCommandTest extends TestCase
         File::deleteDirectory(storage_path('tenants'));
     }
 
-    /** @test */
+    #[Test]
     public function it_create_the_folder_for_the_correct_tenant()
     {
         $path = storage_path('tenants/co/app/public');
@@ -48,7 +49,7 @@ class TenantsSkeletonStorageCommandTest extends TestCase
         $this->assertTrue(File::exists($path));
     }
 
-    /** @test */
+    #[Test]
     public function it_fails_with_a_not_existent_tenant()
     {
         $this
@@ -57,7 +58,7 @@ class TenantsSkeletonStorageCommandTest extends TestCase
             ->expectsOutput('No tenant(s) found.');
     }
 
-    /** @test */
+    #[Test]
     public function it_works_with_no_tenant_parameters()
     {
         $coPath = storage_path('tenants/co/app/public');
@@ -73,7 +74,7 @@ class TenantsSkeletonStorageCommandTest extends TestCase
         $this->assertTrue(File::exists($prPath));
     }
 
-    /** @test */
+    #[Test]
     public function it_fails_creating_folders_if_the_option_is_not_enabled()
     {
         config()->set('multitenancy.suffix_storage_path', false);
@@ -84,7 +85,7 @@ class TenantsSkeletonStorageCommandTest extends TestCase
             ->expectsOutput('Storage tenancies are not enabled.');
     }
 
-    /** @test */
+    #[Test]
     public function fails_to_create_existing_folders()
     {
         $path = storage_path('tenants/co/app/public');

--- a/tests/Feature/Controllers/TenantControllerTest.php
+++ b/tests/Feature/Controllers/TenantControllerTest.php
@@ -3,12 +3,13 @@
 namespace Placetopay\Cerberus\Tests\Feature\Controllers;
 
 use Illuminate\Support\Facades\Cache;
+use PHPUnit\Framework\Attributes\Test;
 use Placetopay\Cerberus\Models\Tenant;
 use Placetopay\Cerberus\Tests\TestCase;
 
 class TenantControllerTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function it_can_access_to_clean_cache_ok()
     {
         $key = 'app-key123234';

--- a/tests/Feature/Controllers/TenantControllerTest.php
+++ b/tests/Feature/Controllers/TenantControllerTest.php
@@ -21,7 +21,7 @@ class TenantControllerTest extends TestCase
 
         $signature = hash_hmac('sha256', json_encode($data), $key);
 
-        $tenant = factory(Tenant::class)->create([
+        $tenant = Tenant::factory()->create([
             'app' => config('multitenancy.identifier'),
             'name' => 'tenant_1',
             'domain' => 'co.domain.com',

--- a/tests/Feature/TenantFinder/DomainTenantFinderTest.php
+++ b/tests/Feature/TenantFinder/DomainTenantFinderTest.php
@@ -3,6 +3,8 @@
 namespace Placetopay\Cerberus\Tests\Feature\TenantFinder;
 
 use Illuminate\Http\Request;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use Placetopay\Cerberus\Models\Tenant;
 use Placetopay\Cerberus\TenantFinder\DomainTenantFinder;
 use Placetopay\Cerberus\Tests\TestCase;
@@ -18,7 +20,7 @@ class DomainTenantFinderTest extends TestCase
         $this->tenantFinder = new DomainTenantFinder();
     }
 
-    /** @test */
+    #[Test]
     public function it_can_find_a_tenant_for_the_current_domain()
     {
         $tenant = factory(Tenant::class)->create([
@@ -31,7 +33,7 @@ class DomainTenantFinderTest extends TestCase
         $this->assertEquals($tenant->id, $this->tenantFinder->findForRequest($request)->id);
     }
 
-    /** @test */
+    #[Test]
     public function it_will_return_null_if_there_are_no_tenants()
     {
         $request = Request::create('https://my-domain.com');
@@ -39,7 +41,7 @@ class DomainTenantFinderTest extends TestCase
         $this->assertNull($this->tenantFinder->findForRequest($request));
     }
 
-    /** @test */
+    #[Test]
     public function it_will_return_null_if_no_tenant_can_be_found_for_the_current_domain()
     {
         factory(Tenant::class)->create([
@@ -52,10 +54,8 @@ class DomainTenantFinderTest extends TestCase
         $this->assertNull($this->tenantFinder->findForRequest($request));
     }
 
-    /**
-     * @dataProvider tenantWithPathProvider
-     * @test
-     */
+    #[Test]
+    #[DataProvider('tenantWithPathProvider')]
     public function it_can_find_a_tenant_for_domain_with_path(
         string $tenantDomain,
         string $requestUrl,

--- a/tests/Feature/TenantFinder/DomainTenantFinderTest.php
+++ b/tests/Feature/TenantFinder/DomainTenantFinderTest.php
@@ -23,7 +23,7 @@ class DomainTenantFinderTest extends TestCase
     #[Test]
     public function it_can_find_a_tenant_for_the_current_domain()
     {
-        $tenant = factory(Tenant::class)->create([
+        $tenant = Tenant::factory()->create([
             'app' => config('multitenancy.identifier'),
             'domain' => 'my-domain.com',
         ]);
@@ -44,7 +44,7 @@ class DomainTenantFinderTest extends TestCase
     #[Test]
     public function it_will_return_null_if_no_tenant_can_be_found_for_the_current_domain()
     {
-        factory(Tenant::class)->create([
+        Tenant::factory()->create([
             'app' => config('multitenancy.identifier'),
             'domain' => 'my-domain.com',
         ]);
@@ -61,7 +61,7 @@ class DomainTenantFinderTest extends TestCase
         string $requestUrl,
         array $requestOptions
     ): void {
-        $registeredTenant = factory(Tenant::class)->create([
+        $registeredTenant = Tenant::factory()->create([
             'app' => config('multitenancy.identifier'),
             'domain' => $tenantDomain,
         ]);

--- a/tests/Support/MemoryLogHandler.php
+++ b/tests/Support/MemoryLogHandler.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Placetopay\Cerberus\Tests\Support;
+
+use Monolog\Handler\AbstractProcessingHandler;
+use Monolog\LogRecord;
+
+class MemoryLogHandler extends AbstractProcessingHandler
+{
+    public array $records = [];
+
+    protected function write(LogRecord $record): void
+    {
+        $this->records[] = $record;
+    }
+}

--- a/tests/Support/NonTenantAwareJob.php
+++ b/tests/Support/NonTenantAwareJob.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Placetopay\Cerberus\Tests\Support;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Spatie\Multitenancy\Jobs\NotTenantAware;
+
+class NonTenantAwareJob implements ShouldQueue, NotTenantAware
+{
+    use InteractsWithQueue, Queueable, SerializesModels;
+
+    public function handle()
+    {
+    }
+}

--- a/tests/Support/TestTenantDomainJob.php
+++ b/tests/Support/TestTenantDomainJob.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Placetopay\Cerberus\Tests\Support;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Log;
+use Spatie\Multitenancy\Concerns\UsesMultitenancyConfig;
+use Spatie\Multitenancy\Jobs\TenantAware;
+
+class TestTenantDomainJob implements ShouldQueue, TenantAware
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+    use UsesMultitenancyConfig;
+
+    public function __construct(public string $tenantName)
+    {
+    }
+
+    public function handle(): void
+    {
+        Log::info("Tenant $this->tenantName: TestTenantDomainJob started");
+    }
+}

--- a/tests/Support/Traits/InteractsWithLogs.php
+++ b/tests/Support/Traits/InteractsWithLogs.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Placetopay\Cerberus\Tests\Support\Traits;
+
+use Illuminate\Support\Facades\Log;
+use Monolog\Handler\TestHandler;
+
+trait InteractsWithLogs
+{
+    protected TestHandler $testLogHandler;
+
+    protected function fakeLogs(): void
+    {
+        $this->testLogHandler = new TestHandler();
+        Log::getLogger()->pushHandler($this->testLogHandler);
+    }
+
+    protected function assertLogMessageContains(string $substring): void
+    {
+        $logFound = collect($this->testLogHandler->getRecords())->contains(function ($record) use ($substring) {
+            return str_contains($record['message'], $substring);
+        });
+
+        $this->assertTrue($logFound, "Expected log message containing '{$substring}' not found.");
+    }
+
+    protected function getAllLogMessages(): array
+    {
+        return array_map(fn ($record) => $record['message'], $this->testLogHandler->getRecords());
+    }
+}

--- a/tests/Tasks/FilesystemSuffixedTaskTest.php
+++ b/tests/Tasks/FilesystemSuffixedTaskTest.php
@@ -3,6 +3,8 @@
 namespace Placetopay\Cerberus\Tests\Tasks;
 
 use Illuminate\Support\Facades\Storage;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use Placetopay\Cerberus\Models\Tenant;
 use Placetopay\Cerberus\Tests\TestCase;
 
@@ -29,7 +31,7 @@ class FilesystemSuffixedTaskTest extends TestCase
         ]);
     }
 
-    /** @test */
+    #[Test]
     public function it_set_suffix_by_tenant_ok()
     {
         $originalStoragePath = Storage::path('tests');
@@ -43,7 +45,7 @@ class FilesystemSuffixedTaskTest extends TestCase
         $this->assertStringContainsString($this->anotherTenant->name, Storage::path('tests'));
     }
 
-    /** @test */
+    #[Test]
     public function it_forget_suffix_by_tenant_ok()
     {
         $this->tenant->makeCurrent();
@@ -59,7 +61,7 @@ class FilesystemSuffixedTaskTest extends TestCase
         $this->assertStringNotContainsString($this->anotherTenant->name, Storage::path('tests'));
     }
 
-    /** @test */
+    #[Test]
     public function it_overwrite_storage_path()
     {
         config()->set('multitenancy.suffix_storage_path', true);
@@ -75,10 +77,8 @@ class FilesystemSuffixedTaskTest extends TestCase
         $this->assertStringNotContainsString($this->tenant->name, $originalStoragePath);
     }
 
-    /**
-     * @test
-     * @dataProvider filesystemDisksUrlDataProvider
-     */
+    #[Test]
+    #[DataProvider('filesystemDisksUrlDataProvider')]
     public function it_overwrite_filesystem_disks_url($appUrl, $storageUrl, $expectedUrl)
     {
         $config = array_merge($this->tenant->config, ['app' => ['url' => $appUrl]]);
@@ -96,7 +96,7 @@ class FilesystemSuffixedTaskTest extends TestCase
         $this->assertSame($expectedUrl, Storage::disk('public')->url(''));
     }
 
-    /** @test */
+    #[Test]
     public function it_forget_filesystem_disk_url_suffix()
     {
         $originalAppUrl = 'https://tenant.test';
@@ -120,14 +120,14 @@ class FilesystemSuffixedTaskTest extends TestCase
     {
         return [
             'tenant_without_trailing_slash' => [
-                'app_url' => 'https://tenant.test',
-                'storage_url' => 'https://tenant_1.test/storage',
-                'expected_url' => 'https://tenant.test/storage/tenants/tenant_1/',
+                'appUrl' => 'https://tenant.test',
+                'storageUrl' => 'https://tenant_1.test/storage',
+                'expectedUrl' => 'https://tenant.test/storage/tenants/tenant_1/',
             ],
             'tenant_with_trailing_slash' => [
-                'app_url' => 'https://tenant_2.test/',
-                'storage_url' => 'https://tenant_2.test/storage/',
-                'expected_url' => 'https://tenant_2.test/storage/tenants/tenant_1/',
+                'appUrl' => 'https://tenant_2.test/',
+                'storageUrl' => 'https://tenant_2.test/storage/',
+                'expectedUrl' => 'https://tenant_2.test/storage/tenants/tenant_1/',
             ],
         ];
     }

--- a/tests/Tasks/FilesystemSuffixedTaskTest.php
+++ b/tests/Tasks/FilesystemSuffixedTaskTest.php
@@ -18,13 +18,13 @@ class FilesystemSuffixedTaskTest extends TestCase
     {
         parent::setUp();
 
-        $this->tenant = factory(Tenant::class)->create([
+        $this->tenant = Tenant::factory()->create([
             'app' => config('multitenancy.identifier'),
             'name' => 'tenant_1',
             'config' => $this->getConfigStructure('laravel_mt_tenant_1'),
         ]);
 
-        $this->anotherTenant = factory(Tenant::class)->create([
+        $this->anotherTenant = Tenant::factory()->create([
             'app' => config('multitenancy.identifier'),
             'name' => 'tenant_2',
             'config' => $this->getConfigStructure('laravel_mt_tenant_2'),

--- a/tests/Tasks/ResetInstanceTaskTest.php
+++ b/tests/Tasks/ResetInstanceTaskTest.php
@@ -12,7 +12,7 @@ class ResetInstanceTaskTest extends TestCase
     {
         parent::setUp();
 
-        $this->tenant = factory(Tenant::class)->create([
+        $this->tenant = Tenant::factory()->create([
             'app' => config('multitenancy.identifier'),
             'name' => 'tenant_1',
             'config' => [
@@ -22,7 +22,7 @@ class ResetInstanceTaskTest extends TestCase
             ],
         ]);
 
-        $this->anotherTenant = factory(Tenant::class)->create([
+        $this->anotherTenant = Tenant::factory()->create([
             'app' => config('multitenancy.identifier'),
             'name' => 'tenant_2',
             'config' => [

--- a/tests/Tasks/ResetInstanceTaskTest.php
+++ b/tests/Tasks/ResetInstanceTaskTest.php
@@ -2,6 +2,7 @@
 
 namespace Placetopay\Cerberus\Tests\Tasks;
 
+use PHPUnit\Framework\Attributes\Test;
 use Placetopay\Cerberus\Models\Tenant;
 use Placetopay\Cerberus\Tests\TestCase;
 
@@ -32,7 +33,7 @@ class ResetInstanceTaskTest extends TestCase
         ]);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_reset_encrypt_container_ok(): void
     {
         config()->set('multitenancy.forget_instances', ['encrypter']);

--- a/tests/Tasks/SwitchMailerTaskTest.php
+++ b/tests/Tasks/SwitchMailerTaskTest.php
@@ -16,19 +16,19 @@ class SwitchMailerTaskTest extends TestCase
     {
         parent::setUp();
 
-        $this->tenant = factory(Tenant::class)->create([
+        $this->tenant = Tenant::factory()->create([
             'app' => config('multitenancy.identifier'),
             'name' => 'tenant_1',
             'config' => ['mail' => ['default' => 'array']],
         ]);
 
-        $this->smtpTenant = factory(Tenant::class)->create([
+        $this->smtpTenant = Tenant::factory()->create([
             'app' => config('multitenancy.identifier'),
             'name' => 'tenant_2',
             'config' => ['mail' => ['default' => 'smtp']],
         ]);
 
-        $this->anotherTenant = factory(Tenant::class)->create([
+        $this->anotherTenant = Tenant::factory()->create([
             'app' => config('multitenancy.identifier'),
             'name' => 'tenant_2',
             'config' => ['mail' => ['default' => 'log']],

--- a/tests/Tasks/SwitchTenantDatabaseTest.php
+++ b/tests/Tasks/SwitchTenantDatabaseTest.php
@@ -19,13 +19,13 @@ class SwitchTenantDatabaseTest extends TestCase
     {
         parent::setUp();
 
-        $this->tenant = factory(Tenant::class)->create([
+        $this->tenant = Tenant::factory()->create([
             'app' => config('multitenancy.identifier'),
             'name' => 'tenant_1',
             'config' => $this->getConfigStructure('laravel_mt_tenant_1'),
         ]);
 
-        $this->anotherTenant = factory(Tenant::class)->create([
+        $this->anotherTenant = Tenant::factory()->create([
             'app' => config('multitenancy.identifier'),
             'name' => 'tenant_2',
             'config' => $this->getConfigStructure('laravel_mt_tenant_2'),

--- a/tests/Tasks/SwitchTenantDatabaseTest.php
+++ b/tests/Tasks/SwitchTenantDatabaseTest.php
@@ -3,8 +3,10 @@
 namespace Placetopay\Cerberus\Tests\Tasks;
 
 use Illuminate\Support\Facades\DB;
+use PHPUnit\Framework\Attributes\Test;
 use Placetopay\Cerberus\Models\Tenant;
 use Placetopay\Cerberus\Tests\TestCase;
+use Spatie\Multitenancy\Contracts\IsTenant;
 use Spatie\Multitenancy\Exceptions\InvalidConfiguration;
 
 class SwitchTenantDatabaseTest extends TestCase
@@ -30,7 +32,7 @@ class SwitchTenantDatabaseTest extends TestCase
         ]);
     }
 
-    /** @test */
+    #[Test]
     public function switch_fails_if_tenant_database_connection_name_equals_to_landlord_connection_name()
     {
         config()->set('multitenancy.tenant_database_connection_name', null);
@@ -40,7 +42,7 @@ class SwitchTenantDatabaseTest extends TestCase
         $this->tenant->makeCurrent();
     }
 
-    /** @test */
+    #[Test]
     public function when_making_a_tenant_current_it_will_perform_the_tasks()
     {
         $this->assertNull(DB::connection('tenant')->getDatabaseName());
@@ -53,7 +55,7 @@ class SwitchTenantDatabaseTest extends TestCase
 
         $this->assertEquals('laravel_mt_tenant_2', DB::connection('tenant')->getDatabaseName());
 
-        Tenant::forgetCurrent();
+        app(IsTenant::class)::forgetCurrent();
 
         $this->assertNull(DB::connection('tenant')->getDatabaseName());
     }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -3,8 +3,8 @@
 namespace Placetopay\Cerberus\Tests;
 
 use Illuminate\Console\Application as Artisan;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
-use Orchestra\Testbench\Concerns\WithLaravelMigrations;
 use Orchestra\Testbench\TestCase as Orchestra;
 use Placetopay\Cerberus\Models\Tenant;
 use Placetopay\Cerberus\TenancyServiceProvider;
@@ -13,7 +13,7 @@ use Placetopay\Cerberus\Tests\Feature\Commands\TestClasses\TenantNoopCommand;
 
 abstract class TestCase extends Orchestra
 {
-    use WithLaravelMigrations;
+    use RefreshDatabase;
 
     public function setUp(): void
     {

--- a/tests/Unit/Middlewares/AppCleanCacheTest.php
+++ b/tests/Unit/Middlewares/AppCleanCacheTest.php
@@ -3,13 +3,14 @@
 namespace Placetopay\Cerberus\Tests\Unit\Middlewares;
 
 use Illuminate\Http\Request;
+use PHPUnit\Framework\Attributes\Test;
 use Placetopay\Cerberus\Http\Exceptions\UnAuthorizedActionException;
 use Placetopay\Cerberus\Http\Middlewares\AppCleanCache;
 use Placetopay\Cerberus\Tests\TestCase;
 
 class AppCleanCacheTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function conf_key_is_not_configured()
     {
         $signature = $this->getSignature('');
@@ -22,7 +23,7 @@ class AppCleanCacheTest extends TestCase
         $middleware->handle($request, fn ($request) => $request);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_not_authenticate()
     {
         $signature = $this->getSignature('app-key123234');

--- a/tests/Unit/TenantTest.php
+++ b/tests/Unit/TenantTest.php
@@ -2,6 +2,7 @@
 
 namespace Placetopay\Cerberus\Tests\Unit;
 
+use PHPUnit\Framework\Attributes\Test;
 use Placetopay\Cerberus\Models\Tenant;
 use Placetopay\Cerberus\Tests\TestCase;
 
@@ -41,7 +42,7 @@ class TenantTest extends TestCase
         config()->set('app.fallback_locale', 'es_CL');
     }
 
-    /** @test */
+    #[Test]
     public function it_return_translation_by_local()
     {
         config()->set('app.locale', 'es_CO');
@@ -53,7 +54,7 @@ class TenantTest extends TestCase
         );
     }
 
-    /** @test */
+    #[Test]
     public function it_return_translation_by_short()
     {
         config()->set('app.locale', 'en_US');
@@ -65,7 +66,7 @@ class TenantTest extends TestCase
         );
     }
 
-    /** @test */
+    #[Test]
     public function it_returns_translation_by_fallback()
     {
         config()->set('app.locale', null);
@@ -78,7 +79,7 @@ class TenantTest extends TestCase
         );
     }
 
-    /** @test */
+    #[Test]
     public function it_return_empty_if_does_not_exist()
     {
         config()->set('app.locale', null);
@@ -89,7 +90,7 @@ class TenantTest extends TestCase
         $this->assertEmpty(app('currentTenant')->translate('terms_and_privacy'));
     }
 
-    /** @test */
+    #[Test]
     public function overwrite_array_keys_config_values_successfully(): void
     {
         config()->set('app.locales', ['en', 'es', 'fr', 'it', 'pt']);

--- a/tests/Unit/TenantTest.php
+++ b/tests/Unit/TenantTest.php
@@ -33,7 +33,7 @@ class TenantTest extends TestCase
             ],
         ];
 
-        $this->tenant = factory(Tenant::class)->create([
+        $this->tenant = Tenant::factory()->create([
             'app' => config('multitenancy.identifier'),
             'name' => 'tenant_1',
             'config' => $config,


### PR DESCRIPTION
# Soporte versión Laravel 12
- [x] Tarea: [PT-14104](https://app.clickup.com/t/31051369/PT-14104)

- [x] Actualización librería spatie/laravel-multitenancy a versión 4
Guia de actualización: [ver..](https://spatie.be/docs/laravel-multitenancy/v4/upgrade-guide)

Dependencias :
- [x] php 8.2
- [x] Upgrade the `phpUnit` package to version `11.5.x`.
- [x] Upgrade `orchestra/testbench` to version `10.3.x`. [Documentación instalación](https://packages.tools/testbench/the-basic.html)
- [x] Upgrade `friendsofphp/php-cs-fixer` to version `3.75.x`.
- [x] Removes  `laravel/legacy-factories`

Nota:
- Actualización config.multitenancy con el del paquete origin
- Actualización casos de pruebas
- Mejoras en phpUnit.xml.dist


